### PR TITLE
Fix: Remove non-existent bats test step causing workflow failure

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,15 +35,6 @@ jobs:
           curl --socks5 localhost:9050 -sS https://check.torproject.org | head -n 1
       - name: Make script executable
         run: chmod +x insta/check_user.sh
-      - name: Run tests
-        run: |
-          # ensure tests run as non-root
-          if [ "$(id -u)" -eq 0 ]; then
-            echo "Tests must run as non-root user in this workflow" >&2
-            exit 1
-          fi
-          # run the project tests
-          bats test/test_check_user.bats
       - name: Run username check
         id: check
         run: |


### PR DESCRIPTION
## Summary
- **Problem**: GitHub Actions workflow failing with error: `/usr/libexec/bats-core/bats: line 103: cd: test: No such file or directory`
- **Root Cause**: Workflow references non-existent test file `test/test_check_user.bats`
- **Solution**: Removed the "Run tests" step that was attempting to execute bats tests that don't exist in the repository

## Changes Made
- Removed the "Run tests" step from `.github/workflows/testing.yml`
- Preserved all other workflow functionality (Tor setup, script execution, username checking, issue creation)
- The workflow now proceeds directly from making the script executable to running the username check

## Test plan
- [ ] Workflow completes successfully without "directory not found" error
- [ ] Tor service starts and validates correctly
- [ ] Script executable permissions are applied
- [ ] Username check executes with provided input
- [ ] GitHub issue is created when a match is found

## Additional Context
The repository does not contain a `test/` directory or any `.bats` test files. The bats-core package was being installed unnecessarily due to this orphaned test step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Contributor**: shubham21155102